### PR TITLE
Fix a stack overflow when doing IPAddress.as_json

### DIFF
--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -105,6 +105,18 @@ module IPAddress;
     end
 
     #
+    # When serializing to JSON format, just use the string representation
+    #
+    #   ip = IPAddress("172.16.100.4/22")
+    #
+    #   ip.as_json
+    #     #=> "172.16.100.4/22"
+    #
+    def as_json
+      to_string
+    end
+
+    #
     # Returns the prefix portion of the IPv4 object
     # as a IPAddress::Prefix32 object
     #

--- a/lib/ipaddress/ipv6.rb
+++ b/lib/ipaddress/ipv6.rb
@@ -118,6 +118,18 @@ module IPAddress;
     end
 
     #
+    # When serializing to JSON format, just use the string representation
+    #
+    #   ip = IPAddress "2001:db8::8:800:200c:417a/64"
+    #
+    #   ip.as_json
+    #     #=> "2001:db8::8:800:200c:417a/64"
+    #
+    def as_json
+      to_string
+    end
+
+    #
     # Returns an array with the 16 bits groups in decimal 
     # format:
     #

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -118,6 +118,11 @@ class IPv4Test < Minitest::Test
     assert_raises(ArgumentError) { @klass.new }
   end
 
+  def test_method_as_json
+    ip = @klass.new("172.16.100.4/22")
+    assert_equal "172.16.100.4/22", ip.as_json
+  end
+
   def test_method_data
     if RUBY_VERSION < "2.0"
       assert_equal "\254\020\n\001", @ip.data

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -67,6 +67,11 @@ class IPv6Test < Minitest::Test
     assert_equal @arr, @ip.groups
   end
 
+  def test_method_as_json
+    ip = @klass.new("2001:db8::8:800:200c:417a/64")
+    assert_equal "2001:db8::8:800:200c:417a/64", ip.as_json
+  end
+
   def test_method_hexs
     arr = "2001:0db8:0000:0000:0008:0800:200c:417a".split(":")
     assert_equal arr, @ip.hexs


### PR DESCRIPTION
Add IPAddress::IPv4#as_json and IPAddress::IPv6#as_json.  If that method
is not defined, then ActiveSupport will create it automatically, but it
overflows the stack due to the way that ipaddress uses #each.

Fixes #89